### PR TITLE
Add ability to populate input fields from query params

### DIFF
--- a/sender/main.js
+++ b/sender/main.js
@@ -89,3 +89,19 @@ function connect() {
 }
 
 $('#kill').on('click', stopApp);
+
+// Populate input fields from query params
+$(function () {
+  if (!'URLSearchParams' in window) {
+    return;
+  }
+
+  var params = new URLSearchParams(window.location.search);
+  if (params.has('url')) {
+    $('#url').val(params.get('url'));
+  }
+
+  if (params.has('refresh')) {
+    $('#refresh').val(params.get('refresh'));
+  }
+});


### PR DESCRIPTION
This PR adds ability to pass values to the input fields from URL query parameters, e.g. `https://boombatower.github.io/chromecast-dashboard/sender/?url=http://my.dashboard.com&refresh=60`

Useful for example when you always want to keep casting the same page and sometimes you need to restart the computer that does the casting and don't want to type the input params again every time. 